### PR TITLE
Fix line break rendering in NBA contract page

### DIFF
--- a/src/components/Projects/nba_contract.js
+++ b/src/components/Projects/nba_contract.js
@@ -97,8 +97,7 @@ function NBAWireframe() {
                         "putting a lot on the line"
                     </a>
                     {' '}by deciding they had to risk their health to secure a good contract.
-
-                    <br />< br />
+                    <br /><br />
                     So that makes sense - players are concerned about how much they can earn in the future. Let's see how this is reflected in their performance.
                 </p>
 


### PR DESCRIPTION
## Summary
- fix malformed line break tag in NBA Contract project page so rendering is correct

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689cec83de64832caeaf34d2ae545e49