### PR TITLE
Improve NBA chart responsiveness on small screens

### DIFF
--- a/src/components/Projects/nba_diy.js
+++ b/src/components/Projects/nba_diy.js
@@ -7,6 +7,7 @@ import { MultiSelect, NumberInput, Checkbox, Group } from '@mantine/core';
 function NBADIY() {
     const [total_data, setTotalData] = useState([]);
     const [filtered_data, setFilteredData] = useState([]);
+    const [isSmallScreen, setIsSmallScreen] = useState(false);
 
     const [filters, setFilters] = useState({
         position: [],
@@ -27,6 +28,13 @@ function NBADIY() {
         { value: '5000000-10000000', label: '5M-10M' },
         { value: '10000000+', label: '10M+' }
     ];
+
+    useEffect(() => {
+        const handleResize = () => setIsSmallScreen(window.innerWidth < 600);
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
 
     useEffect(() => {
         d3.csv(process.env.PUBLIC_URL + "/final_KDE.csv").then(data => {
@@ -63,16 +71,21 @@ function NBADIY() {
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-evenly', marginBottom: '3rem', fontFamily: "Graphik"}}>
+            <div style={{
+                display: 'flex',
+                flexDirection: isSmallScreen ? 'column' : 'row',
+                justifyContent: 'space-evenly',
+                marginBottom: '3rem',
+                fontFamily: "Graphik"
+            }}>
                 <MultiSelect
                     data={positionOptions}
                     value={filters.position}
                     onChange={(value) => setFilters(prev => ({ ...prev, position: value }))}
                     placeholder="Filter by position"
                     label="Position"
-                    size='lg'
-                    w={350}
-                    h={100}
+                    size={isSmallScreen ? 'sm' : 'lg'}
+                    style={{ width: isSmallScreen ? '100%' : 350, marginBottom: isSmallScreen ? '1rem' : 0 }}
                 />
                 <MultiSelect
                     data={ageOptions}
@@ -80,9 +93,8 @@ function NBADIY() {
                     onChange={(value) => setFilters(prev => ({ ...prev, age: value }))}
                     placeholder="Filter by age"
                     label="Age"
-                    size='lg'
-                    w={350}
-                    h={100}
+                    size={isSmallScreen ? 'sm' : 'lg'}
+                    style={{ width: isSmallScreen ? '100%' : 350, marginBottom: isSmallScreen ? '1rem' : 0 }}
                 />
                 <MultiSelect
                     data={salaryOptions}
@@ -90,12 +102,16 @@ function NBADIY() {
                     onChange={(value) => setFilters(prev => ({ ...prev, salary: value }))}
                     placeholder="Filter by salary"
                     label="Salary"
-                    size='lg'
-                    w={350}
-                    h={100}
+                    size={isSmallScreen ? 'sm' : 'lg'}
+                    style={{ width: isSmallScreen ? '100%' : 350 }}
                 />
             </div>
-            <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-evenly' }}>
+            <div style={{
+                display: 'flex',
+                flexDirection: isSmallScreen ? 'column' : 'row',
+                justifyContent: 'space-evenly',
+                alignItems: 'center'
+            }}>
                 <NBAKDEPlot data={filtered_data} />
                 <NBASalaryScatterplot data={filtered_data} />
             </div>

--- a/src/components/Projects/nba_kde_standalone.js
+++ b/src/components/Projects/nba_kde_standalone.js
@@ -19,6 +19,7 @@ class NBAKDEPlot extends Component {
 
     componentDidMount() {
         this.drawDensityplot();
+        window.addEventListener('resize', this.drawDensityplot);
     }
 
     componentDidUpdate(prevProps) {
@@ -29,18 +30,35 @@ class NBAKDEPlot extends Component {
         }
     }
 
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.drawDensityplot);
+    }
+
     drawDensityplot = () => {
-        const totalWidth = 600;
-        const totalHeight = 500;
-        const margin = { top: 10, right: 80, bottom: 60, left: 80 };
+        const containerWidth = this.ref.current.parentNode.getBoundingClientRect().width;
+        const totalWidth = containerWidth;
+        const totalHeight = totalWidth * (500 / 600);
+        const margin = {
+            top: totalWidth * (10 / 600),
+            right: totalWidth * (80 / 600),
+            bottom: totalWidth * (60 / 600),
+            left: totalWidth * (80 / 600)
+        };
         const width = totalWidth - margin.left - margin.right;
         const height = totalHeight - margin.top - margin.bottom;
+
+        const fontScale = totalWidth / 600;
+        const axisFont = 16 * fontScale;
+        const labelFont = 20 * fontScale;
+        const legendFont = 15 * fontScale;
 
         d3.select(this.ref.current).selectAll("*").filter(".kde").remove();
 
         const svg = d3.select(this.ref.current)
-            .attr('width', totalWidth)
-            .attr('height', totalHeight)
+            .attr('viewBox', `0 0 ${totalWidth} ${totalHeight}`)
+            .attr('preserveAspectRatio', 'xMidYMid meet')
+            .style('width', '100%')
+            .style('height', 'auto')
             .append('g')
             .attr('transform', `translate(${margin.left},${margin.top})`);
 
@@ -65,12 +83,12 @@ class NBAKDEPlot extends Component {
 
         svg.append('g')
             .attr("transform", `translate(0,${height})`)
-            .style("font-size", "16px")
+            .style("font-size", `${axisFont}px`)
             .style("font-family", "Graphik")
             .call(d3.axisBottom(xScale));
 
         svg.append('g')
-            .style("font-size", "16px")
+            .style("font-size", `${axisFont}px`)
             .style("font-family", "Graphik")
             .call(d3.axisLeft(yScale).tickFormat(d3.format(".0%")));
 
@@ -82,7 +100,7 @@ class NBAKDEPlot extends Component {
             .text("Performance (WAR) Values")
             .style("font-family", "Graphik")
             .style("fill", "black")
-            .style("font-size", "20px");
+            .style("font-size", `${labelFont}px`);
 
         svg.append("text")
             .attr("text-anchor", "end")
@@ -92,7 +110,7 @@ class NBAKDEPlot extends Component {
             .text("Percentage of Players")
             .style("fill", "black")
             .style("font-family", "Graphik")
-            .style("font-size", "20px");
+            .style("font-size", `${labelFont}px`);
 
         let line = d3.line()
             .curve(d3.curveBasis)
@@ -120,7 +138,7 @@ class NBAKDEPlot extends Component {
             .attr("d", line.y(d => yScale(d[1])));
 
         svg.append("circle").attr("cx", xScale(15)).attr("cy", yScale(.12)).attr("r", 6).style("fill", "#69b3a2")
-        svg.append("text").attr("x", xScale(16)).attr("y", yScale(.1195)).text("Contract Year").style("font-size", "15px").attr("alignment-baseline", "middle")
+        svg.append("text").attr("x", xScale(16)).attr("y", yScale(.1195)).text("Contract Year").style("font-size", `${legendFont}px`).attr("alignment-baseline", "middle")
 
         sigma = d3.deviation(jiggeredData, d => d.previous_war);
         bandwidth = Math.pow(n, -1 / 8) * sigma;
@@ -141,7 +159,7 @@ class NBAKDEPlot extends Component {
             .attr("d", line.y(d => yScale(d[1])));
 
         svg.append("circle").attr("cx", xScale(15)).attr("cy", yScale(.11)).attr("r", 6).style("fill", "#beaed4")
-        svg.append("text").attr("x", xScale(16)).attr("y", yScale(.1095)).text("Pre-Contract Year").style("font-size", "15px").attr("alignment-baseline", "middle")
+        svg.append("text").attr("x", xScale(16)).attr("y", yScale(.1095)).text("Pre-Contract Year").style("font-size", `${legendFont}px`).attr("alignment-baseline", "middle")
 
         sigma = d3.deviation(jiggeredData, d => d.post_contract_war);
         bandwidth = Math.pow(n, -1 / 8) * sigma;
@@ -163,7 +181,7 @@ class NBAKDEPlot extends Component {
             .attr("d", line.y(d => yScale(d[1])));
 
         svg.append("circle").attr("cx", xScale(15)).attr("cy", yScale(.10)).attr("r", 6).style("fill", "#FDC086")
-        svg.append("text").attr("x", xScale(16)).attr("y", yScale(.0995)).text("Post-Contract Year").style("font-size", "15px").attr("alignment-baseline", "middle")
+        svg.append("text").attr("x", xScale(16)).attr("y", yScale(.0995)).text("Post-Contract Year").style("font-size", `${legendFont}px`).attr("alignment-baseline", "middle")
     }
 
     render() {

--- a/src/components/Projects/nba_scatterplot.js
+++ b/src/components/Projects/nba_scatterplot.js
@@ -10,30 +10,48 @@ class NBASalaryScatterplot extends Component {
 
   componentDidMount() {
     this.drawScatterplot();
+    window.addEventListener('resize', this.drawScatterplot);
   }
 
   componentDidUpdate() {
     this.drawScatterplot();
   }
 
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.drawScatterplot);
+  }
+
   drawScatterplot = () => {
-    const totalWidth = 600;
-    const totalHeight = 500;
-    const margin = { top: 10, right: 80, bottom: 60, left: 80 };
+    const containerWidth = this.ref.current.parentNode.getBoundingClientRect().width;
+    const totalWidth = containerWidth;
+    const totalHeight = totalWidth * (500 / 600);
+    const margin = {
+      top: totalWidth * (10 / 600),
+      right: totalWidth * (80 / 600),
+      bottom: totalWidth * (60 / 600),
+      left: totalWidth * (80 / 600)
+    };
     const width = totalWidth - margin.left - margin.right;
     const height = totalHeight - margin.top - margin.bottom;
 
+    const fontScale = totalWidth / 600;
+    const smallFont = 12 * fontScale;
+    const axisFont = 16 * fontScale;
+    const labelFont = 20 * fontScale;
+    const legendFont = 14 * fontScale;
+
     d3.select(this.ref.current).selectAll("*").remove();
 
-  
     const positions = [" PG", " SG", " SF", " PF", " C"];
     const colorScale = d3.scaleOrdinal()
       .domain(positions)
       .range(["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd"]);
 
     const svg = d3.select(this.ref.current)
-      .attr('width', totalWidth)
-      .attr('height', totalHeight);
+      .attr('viewBox', `0 0 ${totalWidth} ${totalHeight}`)
+      .attr('preserveAspectRatio', 'xMidYMid meet')
+      .style('width', '100%')
+      .style('height', 'auto');
 
     const data = this.props.data;
     const jiggeredData = data
@@ -66,7 +84,7 @@ class NBASalaryScatterplot extends Component {
       .attr('y', yScale(0.9))
       .text('Played Better, Paid Better')
       .style('font-family', 'Graphik')
-      .style('font-size', '12px')
+      .style('font-size', `${smallFont}px`)
       .style('fill','#333')
       .attr('text-anchor', 'end');
 
@@ -85,7 +103,7 @@ class NBASalaryScatterplot extends Component {
       .attr('y', yScale(.55))
       .text('Played Worse, Paid Worse')
       .style('font-family', 'Graphik')
-      .style('font-size', '12px')
+      .style('font-size', `${smallFont}px`)
       .style('fill', '#333')
       .attr('text-anchor', 'start');
 
@@ -93,12 +111,12 @@ class NBASalaryScatterplot extends Component {
     const xValues = d3.range(-10, 11, 5);
 
     g.append('g')
-      .style("font-size", "16px")
+      .style("font-size", `${axisFont}px`)
       .style("font-family", "Graphik")
       .call(d3.axisLeft(yScale).tickValues(yValues));
 
     g.append('g')
-      .style("font-size", "16px")
+      .style("font-size", `${axisFont}px`)
       .style("font-family", "Graphik")
       .attr('transform', `translate(0,${height})`)
       .call(d3.axisBottom(xScale).tickValues(xValues));
@@ -167,7 +185,7 @@ class NBASalaryScatterplot extends Component {
       .text("Deviation in WAR")
       .style("font-family", "Graphik")
       .style("fill", "black")
-      .style("font-size", "20px");
+      .style("font-size", `${labelFont}px`);
 
     // Y-axis label
     svg.append("text")
@@ -178,19 +196,64 @@ class NBASalaryScatterplot extends Component {
       .text("Change in Salary")
       .style("fill", "black")
       .style("font-family", "Graphik")
-      .style("font-size", "20px");
+      .style("font-size", `${labelFont}px`);
 
 
-    svg.append("circle").attr("cx", xScale(7)).attr("cy", yScale(-.4)).attr("r", 4).style("fill", "#1f77b4")
-    svg.append("text").attr("x", xScale(7.4)).attr("y", yScale(-.401)).text("Point Guard").style("font-size", "14px").attr("alignment-baseline", "middle")
-    svg.append("circle").attr("cx", xScale(7)).attr("cy", yScale(-.475)).attr("r", 4).style("fill", "#ff7f0e")
-    svg.append("text").attr("x", xScale(7.4)).attr("y", yScale(-.476)).text("Shooting Guard").style("font-size", "14px").attr("alignment-baseline", "middle")
-    svg.append("circle").attr("cx", xScale(7)).attr("cy", yScale(-.55)).attr("r", 4).style("fill", "#2ca02c")
-    svg.append("text").attr("x", xScale(7.4)).attr("y", yScale(-.551)).text("Small Forward").style("font-size", "14px").attr("alignment-baseline", "middle")
-    svg.append("circle").attr("cx", xScale(7)).attr("cy", yScale(-.625)).attr("r", 4).style("fill", "#d62728")
-    svg.append("text").attr("x", xScale(7.4)).attr("y", yScale(-.626)).text("Power Forward").style("font-size", "14px").attr("alignment-baseline", "middle")
-    svg.append("circle").attr("cx", xScale(7)).attr("cy", yScale(-.7)).attr("r", 4).style("fill", "#9467bd")
-    svg.append("text").attr("x", xScale(7.4)).attr("y", yScale(-.701)).text("Center").style("font-size", "14px").attr("alignment-baseline", "middle")
+    svg.append("circle")
+      .attr("cx", xScale(7))
+      .attr("cy", yScale(-.4))
+      .attr("r", 4)
+      .style("fill", "#1f77b4");
+    svg.append("text")
+      .attr("x", xScale(7.4))
+      .attr("y", yScale(-.401))
+      .text("Point Guard")
+      .style("font-size", `${legendFont}px`)
+      .attr("alignment-baseline", "middle");
+    svg.append("circle")
+      .attr("cx", xScale(7))
+      .attr("cy", yScale(-.475))
+      .attr("r", 4)
+      .style("fill", "#ff7f0e");
+    svg.append("text")
+      .attr("x", xScale(7.4))
+      .attr("y", yScale(-.476))
+      .text("Shooting Guard")
+      .style("font-size", `${legendFont}px`)
+      .attr("alignment-baseline", "middle");
+    svg.append("circle")
+      .attr("cx", xScale(7))
+      .attr("cy", yScale(-.55))
+      .attr("r", 4)
+      .style("fill", "#2ca02c");
+    svg.append("text")
+      .attr("x", xScale(7.4))
+      .attr("y", yScale(-.551))
+      .text("Small Forward")
+      .style("font-size", `${legendFont}px`)
+      .attr("alignment-baseline", "middle");
+    svg.append("circle")
+      .attr("cx", xScale(7))
+      .attr("cy", yScale(-.625))
+      .attr("r", 4)
+      .style("fill", "#d62728");
+    svg.append("text")
+      .attr("x", xScale(7.4))
+      .attr("y", yScale(-.626))
+      .text("Power Forward")
+      .style("font-size", `${legendFont}px`)
+      .attr("alignment-baseline", "middle");
+    svg.append("circle")
+      .attr("cx", xScale(7))
+      .attr("cy", yScale(-.7))
+      .attr("r", 4)
+      .style("fill", "#9467bd");
+    svg.append("text")
+      .attr("x", xScale(7.4))
+      .attr("y", yScale(-.701))
+      .text("Center")
+      .style("font-size", `${legendFont}px`)
+      .attr("alignment-baseline", "middle");
   }
 
   render() {


### PR DESCRIPTION
## Summary
- scale SVG text in NBA scatterplot and KDE visuals based on container width
- stack filters and charts vertically with smaller UI on narrow viewports

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_689cef8ac220832ca07b641656ebd7a2