### PR TITLE
Improve NBA contract page responsiveness

### DIFF
--- a/src/components/Projects/nbaScroll.js
+++ b/src/components/Projects/nbaScroll.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import injectSheet from 'react-jss';
 import { Scrollama, Step } from 'react-scrollama';
 import * as d3 from 'd3';
+import "../../styles/nba.css";
 
 let maxData = 0;
 let done = false;
@@ -56,6 +57,7 @@ const styles = {
 };
 
 class NBAScroll extends PureComponent {
+  chartRef = React.createRef();
   state = {
     data: 0,
     steps: [0, 1, 2, 3, 4],
@@ -502,11 +504,25 @@ class NBAScroll extends PureComponent {
   };
 
   componentDidMount() {
+    window.addEventListener('resize', this.handleResize);
     this.initLineChart({
-      width: window.innerWidth * 0.55,
+      width: this.chartRef.current.getBoundingClientRect().width,
       height: 400
     });
     this.onStepEnter({ data: this.state.steps[0] });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  handleResize = () => {
+    d3.select(this.chartRef.current).selectAll('*').remove();
+    this.initLineChart({
+      width: this.chartRef.current.getBoundingClientRect().width,
+      height: 400
+    });
+    this.updateLineChart();
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -535,7 +551,7 @@ class NBAScroll extends PureComponent {
     this.yScale = config.yScale.range([h, 0]);
 
     const svg = d3
-      .select(this.refs.chart)
+      .select(this.chartRef.current)
       .append("svg")
       .attr("width", width + margin.left + margin.right + margin.right)  // Increase the width of the SVG
       .attr("height", height + margin.top + margin.bottom)  // Increase the height of the SVG
@@ -598,7 +614,7 @@ class NBAScroll extends PureComponent {
   };
 
   updateLineChart = () => {
-    const svg = d3.select(this.refs.chart).select('svg');
+    const svg = d3.select(this.chartRef.current).select('svg');
     if (this.state.data === maxData && !done) {
       if (this.state.data in this.state.stepLines) {
         // Iterate over the list of dictionaries for the current step
@@ -796,16 +812,12 @@ class NBAScroll extends PureComponent {
               })}
             </Scrollama>
           </div>
-          <div className={classes.graphic} ref="chart" style={{ display: this.state.data === 0 ? 'none' : 'block' }}>
+          <div className={classes.graphic} ref={this.chartRef} style={{ display: this.state.data === 0 ? 'none' : 'block' }}>
             <p
+              className="chart-title"
               style={{
                 visibility: this.state.data === 0 ? 'hidden' : 'visible',
                 opacity: this.state.data === 0 ? 0 : 1,
-                fontFamily: "Graphik",
-                fontWeight: 400,
-                fontSize: '1.5rem',
-                alignSelf: 'left',
-                color: 'black',
               }}
             >
               Player Performance Before, During, and After Contract Years

--- a/src/components/Projects/nba_contract.js
+++ b/src/components/Projects/nba_contract.js
@@ -1,6 +1,7 @@
 import NBAScroll from "./nbaScroll";
 import NBAKDE from "./nba_kde";
 import NBADIY from "./nba_diy";
+import "../../styles/nba.css";
 
 function NBAWireframe() {
     return (
@@ -16,6 +17,7 @@ function NBAWireframe() {
             {/* Button that returns back to main page, stickied on top left. */}
             <a
                 href="?ref=projects"
+                className="back-button"
                 style={{
                     position: 'fixed',
                     top: '1rem',
@@ -28,7 +30,6 @@ function NBAWireframe() {
                     textDecoration: 'none',
                     borderRadius: '0.5rem',
                     fontWeight: 500,
-                    fontSize: `.8rem`,
                     fontFamily: "Graphik",
                 }}
             >
@@ -45,50 +46,17 @@ function NBAWireframe() {
                 <img
                     src={process.env.PUBLIC_URL + "/title_nba.png"}
                     alt="The Contract Year Phenomenon"
-                    style={{
-                        maxHeight: '55rem',
-                        maxWidth: '45rem',
-                        alignSelf: 'center',
-                        marginTop: '10rem',
-                        marginBottom: '0rem'
-                    }}
+                    className="nba-title-img"
                 />
                 <h3
-                    style={{
-                        marginTop: '0rem',
-                        marginBottom: '12rem',
-                        fontFamily: "Grouch",
-                        fontWeight: 400,
-                        fontSize: `1.5rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        textAlign: 'center',
-                        color: '#86020e'
-                    }}
+                    className="nba-subhead"
                 >
                     Story by Raj Shah
                 </h3>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `1.7rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        paddingInline: '5rem',
-                        color: '#213052',
-                        marginBottom: '8rem'
-                    }}
-                >
-
+                <p className="nba-paragraph">
                     In 2020, the world was grappling with a global pandemic, and the NBA was also struggling.
                     The league somehow pulled off playoffs after a total hiatus in both games and training, leading to a spectacular Bubble Season.<br /><br />
-                    <span
-                        style={{
-                            fontSize: `1.3rem`,
-                            marginBlock: '0rem',
-                        }}
-                    >
+                    <span className="nba-small-text">
                         I'm still wondering where that <span style={{ color: '#86020e', fontWeight: 500 }}>
                             2020 Heat Team </span> went. </span><br /><br />
 
@@ -113,19 +81,7 @@ function NBAWireframe() {
                 >
                     <NBAKDE />
                 </div>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `1.4rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        paddingInline: '10rem',
-                        marginTop: '-5rem',
-                        marginBottom: '2rem',
-                        textAlign: 'justify'
-                    }}
-                >
+                <p className="nba-paragraph-wide" style={{ marginTop: '-5rem', marginBottom: '2rem' }}>
                     Not exactly - there has been a lot of prior research on this topic, showing different methodologies, and coming to some different conclusions.
                     <ul>
                         <li>
@@ -158,68 +114,24 @@ function NBAWireframe() {
                     </ul>
                     So what does this all mean? <br /> There are a lot of factors that go into seeing the relationship between player performance and contract year.<br /><br />What might make it easier to understand is to see the data for ourselves.
                 </p>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `1.4rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        paddingInline: '10rem',
-                        marginBottom: '10rem',
-                        textAlign: 'justify'
-                    }}
-                >
+                <p className="nba-paragraph-wide" style={{ marginBottom: '10rem' }}>
                     One of the graphs below covers what we’ve already seen - the estimated percentage distributions for player performance, delineated by year related to contract. The other is a new one - this one shows how much a player's salary increases based on their change in performance during the contract year.
                     <br /><br />
-                    <span style={{ fontSize: `1.2rem`, marginBlock: '0rem' }}>
+                    <span className="nba-caption">
                         Both of these graphs are made up of 300+ players spanning 2 decades of NBA history.
                         <br /><br />
                         Try seeing how Young Centers do in their contract year, or how younger Point Guards tend to get rewarded versus older Point Guards.
                     </span>
                 </p>
 
-                <div
-                    style={{
-                        marginTop: '-8rem',
-                        marginBottom: '5rem',
-                        paddingInline: '5rem',
-                    }}
-                >
+                <div className="nba-chart-wrapper" style={{ marginTop: '-8rem', marginBottom: '5rem' }}>
                     <NBADIY />
                 </div>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `1.4rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        paddingInline: '15rem',
-                        marginBottom: '5rem',
-                        textAlign: 'justify'
-                    }}
-                >
-                    {/* Make a Span of Centered Text */}
-                    <span
-                        style={{
-                            display: 'block',
-                            textAlign: 'center',
-                            fontSize: `2rem`,
-                            marginBlock: '2rem',
-                            color: '#86020e',
-                            fontFamily: 'Grouch',
-
-                        }}
-                    >
+                <p className="nba-paragraph-wider">
+                    <span className="nba-section-title">
                         So What's the Takeaway?
                     </span>
-                    <span
-                        style={{
-                            fontSize: `1.5rem`,
-                            fontWeight: 500,
-                        }}
-                    >
+                    <span className="nba-small-text" style={{ fontWeight: 500 }}>
                         Does the{' '}
                         <span
                             style={{
@@ -235,12 +147,7 @@ function NBAWireframe() {
                     <br /><br />
                     Kind of. Different players in different situations are going to act...<span style={{ fontWeight: 500 }}>different</span>. And regardless of how they change their game, it's not a given that they'll get paid more.
                     <br /><br /><br />
-                    <span
-                        style={{
-                            fontSize: `1.5rem`,
-                            fontWeight: 500,
-                        }}
-                    >
+                    <span className="nba-small-text" style={{ fontWeight: 500 }}>
                         So Why Does This Matter?
                     </span>
                     <ul>
@@ -253,12 +160,7 @@ function NBAWireframe() {
                         </li>
                     </ul>
                     <br /><br />
-                    <span
-                        style={{
-                            fontSize: `1.5rem`,
-                            fontWeight: 500,
-                        }}
-                    >
+                    <span className="nba-small-text" style={{ fontWeight: 500 }}>
                         How Can I Learn More?
                     </span>
                     <ul>
@@ -283,15 +185,10 @@ function NBAWireframe() {
                         display: 'flex',
                         flexDirection: 'column',
                         marginBottom: '5rem',
-                        paddingInline: '10rem',
                     }}
-                > 
-                <span
-                    style={{
-                        fontSize: `1.5rem`,
-                        fontWeight: 500,
-                    }}
+                    className="nba-sources"
                 >
+                <span className="nba-small-text" style={{ fontWeight: 500 }}>
                     Sources
                 </span>
                 <ul>
@@ -316,23 +213,11 @@ function NBAWireframe() {
                         </a> - This website contains free agent data for different years.
                     </li>
                 </ul>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `.8rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        marginBottom: '10rem',
-                        marginTop: '5rem',
-                        display: 'block',
-                        textAlign: 'center',
-                }}
-                    >
+                <p className="nba-footer">
                         Made by Raj Shah <br/>
                         94470 Telling Stories With Data <br/>
                         Christopher Goranson
-                    </p> 
+                    </p>
 
                 </div>
             </div>

--- a/src/components/Projects/nba_kde.js
+++ b/src/components/Projects/nba_kde.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import * as d3 from 'd3';
 import injectSheet from 'react-jss';
 import { Scrollama, Step } from 'react-scrollama';
+import "../../styles/nba.css";
 
 function epanechnikov(bandwidth) {
     return x => Math.abs(x /= bandwidth) <= 1 ? (0.75 * (1 - x * x)) / bandwidth : 0;
@@ -57,6 +58,7 @@ const styles = {
 };
 
 class NBAKDE extends Component {
+    chartRef = React.createRef();
     state = {
         data: 0,
         kde_data: [],
@@ -75,20 +77,34 @@ class NBAKDE extends Component {
     };
 
     componentDidMount() {
+        window.addEventListener('resize', this.handleResize);
         this.loadData().then(() => {
-            this.setupVisualization([this.state.kde_data]);
+            this.updateChart();
         });
     }
 
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.handleResize);
+    }
+
+    updateChart = () => {
+        d3.select(this.chartRef.current).selectAll('*').remove();
+        this.setupVisualization([this.state.kde_data]);
+    }
+
+    handleResize = () => {
+        this.updateChart();
+    }
+
     setupVisualization = (kde_data_set) => {
-        const totalWidth = window.innerWidth * 0.45;
+        const totalWidth = this.chartRef.current.getBoundingClientRect().width;
         const totalHeight = 400;
         const margin = { top: 20, right: 10, bottom: 80, left: 80 };
         const width = totalWidth - margin.left - margin.right;
         const height = totalHeight - margin.top - margin.bottom;
     
         // Create the SVG container
-        const svg = d3.select(this.refs.chart)
+        const svg = d3.select(this.chartRef.current)
             .append("svg")
             .attr("width", totalWidth)
             .attr("height", totalHeight)
@@ -343,15 +359,10 @@ class NBAKDE extends Component {
                         </Scrollama>
                     </div>
 
-                    <div className={classes.graphic} ref="chart" style={{ display: 'block' }}>
+                    <div className={classes.graphic} ref={this.chartRef} style={{ display: 'block' }}>
                         <p
+                            className="chart-title"
                             style={{
-                                fontFamily: "Graphik",
-                                fontWeight: 400,
-                                fontSize: '1.5rem',
-                                alignSelf: 'left',
-                                color: 'black',
-                                paddingInline: '16rem',
                                 marginLeft: '-16rem',
                                 marginBottom: '0rem',
                             }}

--- a/src/components/Projects/nba_kde_standalone.js
+++ b/src/components/Projects/nba_kde_standalone.js
@@ -14,9 +14,11 @@ class NBAKDEPlot extends Component {
         super(props);
         this.ref = React.createRef();
         this.tooltipRef = React.createRef();
+        this.containerRef = React.createRef();
     }
 
     componentDidMount() {
+        window.addEventListener('resize', this.drawDensityplot);
         this.drawDensityplot();
     }
 
@@ -26,8 +28,12 @@ class NBAKDEPlot extends Component {
         }
     }
 
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.drawDensityplot);
+    }
+
     drawDensityplot = () => {
-        const totalWidth = 600;
+        const totalWidth = this.containerRef.current.getBoundingClientRect().width;
         const totalHeight = 500;
         const margin = { top: 10, right: 80, bottom: 60, left: 80 };
         const width = totalWidth - margin.left - margin.right;
@@ -162,7 +168,7 @@ class NBAKDEPlot extends Component {
 
     render() {
         return (
-            <div>
+            <div ref={this.containerRef} style={{ width: '100%' }}>
                 <div ref={this.tooltipRef} style={{ position: 'absolute', visibility: 'hidden' }} />
                 <svg ref={this.ref} />
             </div>

--- a/src/components/Projects/nba_scatterplot.js
+++ b/src/components/Projects/nba_scatterplot.js
@@ -6,10 +6,16 @@ class NBASalaryScatterplot extends Component {
     super(props);
     this.ref = React.createRef();
     this.tooltipRef = React.createRef(); // Add this line
+    this.containerRef = React.createRef();
   }
 
   componentDidMount() {
+    window.addEventListener('resize', this.drawScatterplot);
     this.drawScatterplot();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.drawScatterplot);
   }
 
   componentDidUpdate() {
@@ -17,7 +23,7 @@ class NBASalaryScatterplot extends Component {
   }
 
   drawScatterplot = () => {
-    const totalWidth = 600;
+    const totalWidth = this.containerRef.current.getBoundingClientRect().width;
     const totalHeight = 500;
     const margin = { top: 10, right: 80, bottom: 60, left: 80 };
     const width = totalWidth - margin.left - margin.right;
@@ -195,7 +201,7 @@ class NBASalaryScatterplot extends Component {
 
   render() {
     return (
-      <div>
+      <div ref={this.containerRef} style={{ width: '100%' }}>
         <div ref={this.tooltipRef} style={{ position: 'absolute', visibility: 'hidden' }} />
         <svg ref={this.ref} />
       </div>

--- a/src/styles/nba.css
+++ b/src/styles/nba.css
@@ -1,0 +1,137 @@
+.nba-title-img {
+  max-width: 45vw;
+  max-height: 55vh;
+  align-self: center;
+  margin-top: 10vh;
+  margin-bottom: 0;
+}
+
+.nba-subhead {
+  margin-top: 0;
+  margin-bottom: 12vh;
+  font-family: 'Grouch';
+  font-weight: 400;
+  font-size: 2vw;
+  line-height: 1.4;
+  width: 100%;
+  text-align: center;
+  color: #86020e;
+}
+
+.nba-paragraph {
+  font-family: 'Graphik';
+  font-weight: 400;
+  line-height: 1.4;
+  width: 100%;
+  padding-inline: 5vw;
+  color: #213052;
+  margin-bottom: 8vh;
+  font-size: 2.2vw;
+}
+
+.nba-paragraph-wide {
+  font-family: 'Graphik';
+  font-weight: 400;
+  line-height: 1.4;
+  width: 100%;
+  padding-inline: 10vw;
+  margin-bottom: 8vh;
+  font-size: 1.8vw;
+  text-align: justify;
+}
+
+.nba-paragraph-wider {
+  font-family: 'Graphik';
+  font-weight: 400;
+  line-height: 1.4;
+  width: 100%;
+  padding-inline: 15vw;
+  margin-bottom: 5vh;
+  font-size: 1.8vw;
+  text-align: justify;
+}
+
+.nba-small-text {
+  font-size: 1.8vw;
+}
+
+.nba-caption {
+  font-size: 1.5vw;
+}
+
+.nba-section-title {
+  display: block;
+  text-align: center;
+  font-size: 3vw;
+  margin-block: 2rem;
+  color: #86020e;
+  font-family: 'Grouch';
+}
+
+.chart-title {
+  font-family: 'Graphik';
+  font-weight: 400;
+  font-size: 2vw;
+  align-self: left;
+  color: black;
+}
+
+.nba-chart-wrapper {
+  padding-inline: 5vw;
+}
+
+.nba-sources {
+  padding-inline: 10vw;
+}
+
+.nba-footer {
+  font-family: 'Graphik';
+  font-weight: 400;
+  font-size: 1vw;
+  line-height: 1.4;
+  width: 100%;
+  margin-bottom: 10vh;
+  margin-top: 5vh;
+  display: block;
+  text-align: center;
+}
+
+.back-button {
+  font-size: 1.5vw;
+}
+
+@media (max-width: 768px) {
+  .nba-title-img {
+    max-width: 80vw;
+  }
+  .nba-subhead {
+    font-size: 4vw;
+  }
+  .nba-paragraph {
+    font-size: 4vw;
+    padding-inline: 3vw;
+  }
+  .nba-paragraph-wide {
+    font-size: 3.5vw;
+    padding-inline: 5vw;
+  }
+  .nba-paragraph-wider {
+    font-size: 3.5vw;
+    padding-inline: 8vw;
+  }
+  .nba-small-text {
+    font-size: 3vw;
+  }
+  .nba-caption {
+    font-size: 2.5vw;
+  }
+  .chart-title {
+    font-size: 4vw;
+  }
+  .back-button {
+    font-size: 3vw;
+  }
+  .nba-footer {
+    font-size: 2.5vw;
+  }
+}


### PR DESCRIPTION
## Summary
- replace inline sizing in contract page with responsive CSS classes
- recompute chart dimensions from container and redraw on window resize
- centralize shared NBA styles for easier responsive tweaks

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689cf9c269cc832cbc376980f6e34fe4