### PR TITLE
Make NBA pages responsive

### DIFF
--- a/src/components/Projects/nba_contract.css
+++ b/src/components/Projects/nba_contract.css
@@ -1,0 +1,167 @@
+.nba-back-button {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 100;
+  background-color: #213052;
+  opacity: 0.8;
+  color: #FCF3D9;
+  padding: 0.5rem 0.75rem;
+  text-decoration: none;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  font-family: "Graphik";
+  font-size: 1.2vw;
+}
+
+.nba-title-image {
+  max-width: 60vw;
+  max-height: 80vh;
+  align-self: center;
+  margin-top: 10vh;
+  margin-bottom: 0;
+}
+
+.nba-heading {
+  margin-top: 0;
+  margin-bottom: 12vh;
+  font-family: "Grouch";
+  font-weight: 400;
+  font-size: 2.5vw;
+  line-height: 1.4;
+  width: 100%;
+  text-align: center;
+  color: #86020e;
+}
+
+.nba-text {
+  font-family: "Graphik";
+  font-weight: 400;
+  line-height: 1.4;
+  width: 100%;
+  padding-inline: 5vw;
+  color: #213052;
+  margin-bottom: 8vh;
+  font-size: 1.7vw;
+}
+
+.nba-text.small {
+  font-size: 1.4vw;
+}
+
+.nba-text.pad-10 {
+  padding-inline: 10vw;
+}
+
+.nba-text.pad-15 {
+  padding-inline: 15vw;
+}
+
+.nba-note {
+  font-size: 1.3vw;
+  margin-block: 0;
+}
+
+.nba-subnote {
+  font-size: 1.2vw;
+  margin-block: 0;
+}
+
+.nba-section-title {
+  display: block;
+  text-align: center;
+  font-size: 2vw;
+  margin-block: 2rem;
+  color: #86020e;
+  font-family: 'Grouch';
+}
+
+.nba-highlight {
+  font-size: 1.5vw;
+  font-weight: 500;
+}
+
+.nba-diy-container {
+  margin-top: -8rem;
+  margin-bottom: 5rem;
+  padding-inline: 5vw;
+}
+
+.nba-sources-container {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 5rem;
+  padding-inline: 10vw;
+}
+
+.nba-sources-text {
+  font-family: "Graphik";
+  font-weight: 400;
+  line-height: 1.4;
+  width: 100%;
+  display: block;
+  text-align: center;
+  margin-top: 5rem;
+  margin-bottom: 10rem;
+  font-size: 0.8vw;
+}
+
+@media (max-width: 768px) {
+  .nba-back-button {
+    font-size: 3vw;
+  }
+
+  .nba-title-image {
+    max-width: 90vw;
+  }
+
+  .nba-heading {
+    font-size: 6vw;
+    margin-bottom: 8vh;
+  }
+
+  .nba-text {
+    font-size: 4vw;
+    padding-inline: 5vw;
+  }
+
+  .nba-text.small {
+    font-size: 3.5vw;
+  }
+
+  .nba-text.pad-10 {
+    padding-inline: 7vw;
+  }
+
+  .nba-text.pad-15 {
+    padding-inline: 10vw;
+  }
+
+  .nba-note {
+    font-size: 3vw;
+  }
+
+  .nba-subnote {
+    font-size: 2.5vw;
+  }
+
+  .nba-section-title {
+    font-size: 4vw;
+  }
+
+  .nba-highlight {
+    font-size: 3vw;
+  }
+
+  .nba-diy-container {
+    padding-inline: 5vw;
+  }
+
+  .nba-sources-container {
+    padding-inline: 7vw;
+  }
+
+  .nba-sources-text {
+    font-size: 2vw;
+  }
+}

--- a/src/components/Projects/nba_contract.js
+++ b/src/components/Projects/nba_contract.js
@@ -1,6 +1,7 @@
 import NBAScroll from "./nbaScroll";
 import NBAKDE from "./nba_kde";
 import NBADIY from "./nba_diy";
+import "./nba_contract.css";
 
 function NBAWireframe() {
     return (
@@ -14,24 +15,7 @@ function NBAWireframe() {
             }}
         >
             {/* Button that returns back to main page, stickied on top left. */}
-            <a
-                href="?ref=projects"
-                style={{
-                    position: 'fixed',
-                    top: '1rem',
-                    left: '1rem',
-                    zIndex: 100,
-                    backgroundColor: '#213052',
-                    opacity: 0.8,
-                    color: '#FCF3D9',
-                    padding: '0.5rem .75rem',
-                    textDecoration: 'none',
-                    borderRadius: '0.5rem',
-                    fontWeight: 500,
-                    fontSize: `.8rem`,
-                    fontFamily: "Graphik",
-                }}
-            >
+            <a href="?ref=projects" className="nba-back-button">
                 Back
             </a>
             <div
@@ -45,52 +29,19 @@ function NBAWireframe() {
                 <img
                     src={process.env.PUBLIC_URL + "/title_nba.png"}
                     alt="The Contract Year Phenomenon"
-                    style={{
-                        maxHeight: '55rem',
-                        maxWidth: '45rem',
-                        alignSelf: 'center',
-                        marginTop: '10rem',
-                        marginBottom: '0rem'
-                    }}
+                    className="nba-title-image"
                 />
-                <h3
-                    style={{
-                        marginTop: '0rem',
-                        marginBottom: '12rem',
-                        fontFamily: "Grouch",
-                        fontWeight: 400,
-                        fontSize: `1.5rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        textAlign: 'center',
-                        color: '#86020e'
-                    }}
-                >
+                <h3 className="nba-heading">
                     Story by Raj Shah
                 </h3>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `1.7rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        paddingInline: '5rem',
-                        color: '#213052',
-                        marginBottom: '8rem'
-                    }}
-                >
+                <p className="nba-text">
 
                     In 2020, the world was grappling with a global pandemic, and the NBA was also struggling.
                     The league somehow pulled off playoffs after a total hiatus in both games and training, leading to a spectacular Bubble Season.<br /><br />
-                    <span
-                        style={{
-                            fontSize: `1.3rem`,
-                            marginBlock: '0rem',
-                        }}
-                    >
+                    <span className="nba-note">
                         I'm still wondering where that <span style={{ color: '#86020e', fontWeight: 500 }}>
-                            2020 Heat Team </span> went. </span><br /><br />
+                            2020 Heat Team </span> went.
+                    </span><br /><br />
 
                     Players went on the record to discuss how they felt uncertain about playing that year - Jayson Tatum famously said that free agent players were{' '}
                     <a href="https://www.espn.com/nba/story/_/id/29423982/celtics-jayson-tatum-says-nba-players-contract-years-putting-lot-line" target="_blank" rel="noreferrer">
@@ -113,19 +64,7 @@ function NBAWireframe() {
                 >
                     <NBAKDE />
                 </div>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `1.4rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        paddingInline: '10rem',
-                        marginTop: '-5rem',
-                        marginBottom: '2rem',
-                        textAlign: 'justify'
-                    }}
-                >
+                <p className="nba-text small pad-10" style={{ marginTop: '-5rem', marginBottom: '2rem', textAlign: 'justify' }}>
                     Not exactly - there has been a lot of prior research on this topic, showing different methodologies, and coming to some different conclusions.
                     <ul>
                         <li>
@@ -158,68 +97,25 @@ function NBAWireframe() {
                     </ul>
                     So what does this all mean? <br /> There are a lot of factors that go into seeing the relationship between player performance and contract year.<br /><br />What might make it easier to understand is to see the data for ourselves.
                 </p>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `1.4rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        paddingInline: '10rem',
-                        marginBottom: '10rem',
-                        textAlign: 'justify'
-                    }}
-                >
+                <p className="nba-text small pad-10" style={{ marginBottom: '10rem', textAlign: 'justify' }}>
                     One of the graphs below covers what we’ve already seen - the estimated percentage distributions for player performance, delineated by year related to contract. The other is a new one - this one shows how much a player's salary increases based on their change in performance during the contract year.
                     <br /><br />
-                    <span style={{ fontSize: `1.2rem`, marginBlock: '0rem' }}>
+                    <span className="nba-subnote">
                         Both of these graphs are made up of 300+ players spanning 2 decades of NBA history.
                         <br /><br />
                         Try seeing how Young Centers do in their contract year, or how younger Point Guards tend to get rewarded versus older Point Guards.
                     </span>
                 </p>
 
-                <div
-                    style={{
-                        marginTop: '-8rem',
-                        marginBottom: '5rem',
-                        paddingInline: '5rem',
-                    }}
-                >
+                <div className="nba-diy-container">
                     <NBADIY />
                 </div>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `1.4rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        paddingInline: '15rem',
-                        marginBottom: '5rem',
-                        textAlign: 'justify'
-                    }}
-                >
+                <p className="nba-text small pad-15" style={{ marginBottom: '5rem', textAlign: 'justify' }}>
                     {/* Make a Span of Centered Text */}
-                    <span
-                        style={{
-                            display: 'block',
-                            textAlign: 'center',
-                            fontSize: `2rem`,
-                            marginBlock: '2rem',
-                            color: '#86020e',
-                            fontFamily: 'Grouch',
-
-                        }}
-                    >
+                    <span className="nba-section-title">
                         So What's the Takeaway?
                     </span>
-                    <span
-                        style={{
-                            fontSize: `1.5rem`,
-                            fontWeight: 500,
-                        }}
-                    >
+                    <span className="nba-highlight">
                         Does the{' '}
                         <span
                             style={{
@@ -235,12 +131,7 @@ function NBAWireframe() {
                     <br /><br />
                     Kind of. Different players in different situations are going to act...<span style={{ fontWeight: 500 }}>different</span>. And regardless of how they change their game, it's not a given that they'll get paid more.
                     <br /><br /><br />
-                    <span
-                        style={{
-                            fontSize: `1.5rem`,
-                            fontWeight: 500,
-                        }}
-                    >
+                    <span className="nba-highlight">
                         So Why Does This Matter?
                     </span>
                     <ul>
@@ -253,12 +144,7 @@ function NBAWireframe() {
                         </li>
                     </ul>
                     <br /><br />
-                    <span
-                        style={{
-                            fontSize: `1.5rem`,
-                            fontWeight: 500,
-                        }}
-                    >
+                    <span className="nba-highlight">
                         How Can I Learn More?
                     </span>
                     <ul>
@@ -278,20 +164,8 @@ function NBAWireframe() {
                     </ul>
                 </p>
                 {/* Data Sources */}
-                <div
-                    style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        marginBottom: '5rem',
-                        paddingInline: '10rem',
-                    }}
-                > 
-                <span
-                    style={{
-                        fontSize: `1.5rem`,
-                        fontWeight: 500,
-                    }}
-                >
+                <div className="nba-sources-container">
+                <span className="nba-highlight">
                     Sources
                 </span>
                 <ul>
@@ -316,23 +190,11 @@ function NBAWireframe() {
                         </a> - This website contains free agent data for different years.
                     </li>
                 </ul>
-                <p
-                    style={{
-                        fontFamily: "Graphik",
-                        fontWeight: 400,
-                        fontSize: `.8rem`,
-                        lineHeight: 1.4,
-                        width: '100%',
-                        marginBottom: '10rem',
-                        marginTop: '5rem',
-                        display: 'block',
-                        textAlign: 'center',
-                }}
-                    >
+                <p className="nba-sources-text">
                         Made by Raj Shah <br/>
                         94470 Telling Stories With Data <br/>
                         Christopher Goranson
-                    </p> 
+                </p>
 
                 </div>
             </div>

--- a/src/components/Projects/nba_kde.js
+++ b/src/components/Projects/nba_kde.js
@@ -57,6 +57,11 @@ const styles = {
 };
 
 class NBAKDE extends Component {
+    constructor(props) {
+        super(props);
+        this.chartRef = React.createRef();
+    }
+
     state = {
         data: 0,
         kde_data: [],
@@ -78,17 +83,22 @@ class NBAKDE extends Component {
         this.loadData().then(() => {
             this.setupVisualization([this.state.kde_data]);
         });
+        window.addEventListener('resize', this.handleResize);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.handleResize);
     }
 
     setupVisualization = (kde_data_set) => {
-        const totalWidth = window.innerWidth * 0.45;
+        const totalWidth = this.chartRef.current.getBoundingClientRect().width;
         const totalHeight = 400;
         const margin = { top: 20, right: 10, bottom: 80, left: 80 };
         const width = totalWidth - margin.left - margin.right;
         const height = totalHeight - margin.top - margin.bottom;
     
         // Create the SVG container
-        const svg = d3.select(this.refs.chart)
+        const svg = d3.select(this.chartRef.current)
             .append("svg")
             .attr("width", totalWidth)
             .attr("height", totalHeight)
@@ -162,6 +172,15 @@ class NBAKDE extends Component {
 
         });
         this.setState({ svg, x, y });
+    };
+
+    handleResize = () => {
+        if (this.state.kde_data.length === 0) return;
+        d3.select(this.chartRef.current).select('svg').remove();
+        this.setupVisualization([this.state.kde_data]);
+        if (this.state.data === 1) this.handleStepOne();
+        if (this.state.data === 2) this.handleStepTwo();
+        if (this.state.data === 3) this.handleStepThree();
     };
 
 
@@ -343,7 +362,7 @@ class NBAKDE extends Component {
                         </Scrollama>
                     </div>
 
-                    <div className={classes.graphic} ref="chart" style={{ display: 'block' }}>
+                    <div className={classes.graphic} ref={this.chartRef} style={{ display: 'block' }}>
                         <p
                             style={{
                                 fontFamily: "Graphik",

--- a/src/components/Projects/nba_kde_standalone.js
+++ b/src/components/Projects/nba_kde_standalone.js
@@ -18,6 +18,11 @@ class NBAKDEPlot extends Component {
 
     componentDidMount() {
         this.drawDensityplot();
+        window.addEventListener('resize', this.handleResize);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.handleResize);
     }
 
     componentDidUpdate(prevProps) {
@@ -27,8 +32,9 @@ class NBAKDEPlot extends Component {
     }
 
     drawDensityplot = () => {
-        const totalWidth = 600;
-        const totalHeight = 500;
+        const containerWidth = this.ref.current.parentNode.getBoundingClientRect().width;
+        const totalWidth = containerWidth;
+        const totalHeight = containerWidth * 0.83;
         const margin = { top: 10, right: 80, bottom: 60, left: 80 };
         const width = totalWidth - margin.left - margin.right;
         const height = totalHeight - margin.top - margin.bottom;
@@ -158,6 +164,10 @@ class NBAKDEPlot extends Component {
 
         staticGroup.append('circle').attr('cx', xScale(15)).attr('cy', yScale(0.10)).attr('r', 6).style('fill', '#FDC086');
         staticGroup.append('text').attr('x', xScale(16)).attr('y', yScale(0.0995)).text('Post-Contract Year').style('font-size', '15px').attr('alignment-baseline', 'middle');
+    }
+
+    handleResize = () => {
+        this.drawDensityplot();
     }
 
     render() {

--- a/src/components/Projects/nba_scatterplot.js
+++ b/src/components/Projects/nba_scatterplot.js
@@ -10,22 +10,27 @@ class NBASalaryScatterplot extends Component {
 
   componentDidMount() {
     this.drawScatterplot();
+    window.addEventListener('resize', this.handleResize);
   }
 
   componentDidUpdate() {
     this.drawScatterplot();
   }
 
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
   drawScatterplot = () => {
-    const totalWidth = 600;
-    const totalHeight = 500;
+    const containerWidth = this.ref.current.parentNode.getBoundingClientRect().width;
+    const totalWidth = containerWidth;
+    const totalHeight = containerWidth * 0.83;
     const margin = { top: 10, right: 80, bottom: 60, left: 80 };
     const width = totalWidth - margin.left - margin.right;
     const height = totalHeight - margin.top - margin.bottom;
 
     d3.select(this.ref.current).selectAll("*").remove();
 
-  
     const positions = [" PG", " SG", " SF", " PF", " C"];
     const colorScale = d3.scaleOrdinal()
       .domain(positions)
@@ -192,6 +197,10 @@ class NBASalaryScatterplot extends Component {
     svg.append("circle").attr("cx", xScale(7)).attr("cy", yScale(-.7)).attr("r", 4).style("fill", "#9467bd")
     svg.append("text").attr("x", xScale(7.4)).attr("y", yScale(-.701)).text("Center").style("font-size", "14px").attr("alignment-baseline", "middle")
   }
+
+  handleResize = () => {
+    this.drawScatterplot();
+  };
 
   render() {
     return (


### PR DESCRIPTION
## Summary
- replace NBA article inline sizes with responsive CSS classes and media queries
- resize NBA charts using container width and redraw on window resize

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689d004abd80832ca5cf308a5078e8f0